### PR TITLE
QUED-179 GeoNames-Koordinaten aus TEI für Kartenintegration indexieren

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
@@ -104,6 +108,11 @@
       <version>${mycore.version}</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <!-- provided by mir-module -->
@@ -112,6 +121,26 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mycore</groupId>
+      <artifactId>mycore-restapi</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/de/gbv/reposis/ditav/DitavTEIAccumulator.java
+++ b/src/main/java/de/gbv/reposis/ditav/DitavTEIAccumulator.java
@@ -7,9 +7,16 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -21,11 +28,22 @@ import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 import org.mycore.solr.index.file.MCRSolrFileIndexAccumulator;
 
+import com.google.gson.JsonObject;
+
+import de.gbv.reposis.ditav.geonames.DitavGeoNamesService;
+
 public class DitavTEIAccumulator implements MCRSolrFileIndexAccumulator {
 
     public static final String DITAV_GENERIC_FILE_LINK_SOLR_FIELD = "ditav.mods.dante_file_link";
     public static final String DITAV_PERSON_FILE_LINK_SOLR_FIELD = "ditav.mods.dante_file_pers_link";
     public static final String DITAV_ORGANIZATION_FILE_LINK_SOLR_FIELD = "ditav.mods.dante_file_org_link";
+
+    public static final String DITAV_GEONAMES_ID_SOLR_FIELD = "ditav.tei.geonames_id";
+    public static final String DITAV_GEONAMES_LINK_SOLR_FIELD = "ditav.tei.geonames_link";
+    public static final String DITAV_PLACE_SOLR_FIELD = "ditav.tei.place";
+    public static final String DITAV_COORDINATES_SOLR_FIELD = "ditav.tei.coordinates";
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private static void extractTEIElement(SolrInputDocument document, String elementName,
         String refURIPrefix, Document teiDocument, String... linkFields) {
@@ -71,6 +89,79 @@ public class DitavTEIAccumulator implements MCRSolrFileIndexAccumulator {
         extractTEIElement(document, "orgName",
             "https://uri.gbv.de/terminology/lod_organisations/", teiDocument,
             DITAV_GENERIC_FILE_LINK_SOLR_FIELD, DITAV_ORGANIZATION_FILE_LINK_SOLR_FIELD);
+
+        extractGeoNames(document, teiDocument);
+    }
+
+    /**
+     * Extracts all {@code tei:placeName} elements referencing geonames.org, ensures the
+     * corresponding GeoNames entries are cached locally (fetching them from the GeoNames API on a
+     * cache miss) and adds the geonameId, the reference and the resolved place name to the Solr
+     * document. All resolved coordinates are combined into a single WKT geometry value (a
+     * {@code POINT} for one place, a {@code GEOMETRYCOLLECTION} of points for several) so the
+     * single-valued {@code location_common} field type can hold every place of the document.
+     * <p>
+     * GeoNames resolution is best effort: any failure is logged and must not abort indexing.
+     */
+    private static void extractGeoNames(SolrInputDocument document, Document teiDocument) {
+        XPathExpression<Element> places = XPathFactory.instance().compile(
+            ".//tei:placeName[contains(@ref, 'geonames.org')]", Filters.element(), null, TEI_NAMESPACE);
+
+        DitavGeoNamesService service = DitavGeoNamesService.getInstance();
+        Set<String> seenIds = new LinkedHashSet<>();
+        List<String> coordinatePairs = new ArrayList<>();
+
+        for (Element place : places.evaluate(teiDocument)) {
+            String refAttribute = place.getAttributeValue("ref");
+            if (refAttribute == null) {
+                continue;
+            }
+            for (String ref : refAttribute.split(",")) {
+                String trimmedRef = ref.trim();
+                DitavGeoNamesService.extractGeonameId(trimmedRef)
+                    .filter(seenIds::add)
+                    .ifPresent(geonameId -> indexGeoName(document, service, geonameId, trimmedRef,
+                        coordinatePairs));
+            }
+        }
+
+        buildCoordinateWkt(coordinatePairs)
+            .ifPresent(wkt -> document.addField(DITAV_COORDINATES_SOLR_FIELD, wkt));
+    }
+
+    private static void indexGeoName(SolrInputDocument document, DitavGeoNamesService service,
+        String geonameId, String ref, List<String> coordinatePairs) {
+        document.addField(DITAV_GEONAMES_ID_SOLR_FIELD, geonameId);
+        document.addField(DITAV_GEONAMES_LINK_SOLR_FIELD, ref);
+        try {
+            service.resolveAsJson(geonameId).ifPresent(entry -> {
+                if (entry.has("name")) {
+                    document.addField(DITAV_PLACE_SOLR_FIELD, entry.get("name").getAsString());
+                }
+                DitavGeoNamesService.coordinatePair(entry).ifPresent(coordinatePairs::add);
+            });
+        } catch (RuntimeException e) {
+            LOGGER.warn("Could not resolve GeoNames entry {}", geonameId, e);
+        }
+    }
+
+    /**
+     * Combines the collected {@code "lng lat"} pairs into a single WKT geometry.
+     *
+     * @param coordinatePairs the {@code "lng lat"} pairs of all resolved places
+     * @return a single {@code POINT}/{@code GEOMETRYCOLLECTION} WKT value or empty if there are none
+     */
+    private static Optional<String> buildCoordinateWkt(List<String> coordinatePairs) {
+        if (coordinatePairs.isEmpty()) {
+            return Optional.empty();
+        }
+        if (coordinatePairs.size() == 1) {
+            return Optional.of("POINT (" + coordinatePairs.get(0) + ")");
+        }
+        String points = coordinatePairs.stream()
+            .map(pair -> "POINT (" + pair + ")")
+            .collect(Collectors.joining(", "));
+        return Optional.of("GEOMETRYCOLLECTION (" + points + ")");
     }
 
 }

--- a/src/main/java/de/gbv/reposis/ditav/geonames/DitavGeoNamesCommands.java
+++ b/src/main/java/de/gbv/reposis/ditav/geonames/DitavGeoNamesCommands.java
@@ -1,0 +1,33 @@
+package de.gbv.reposis.ditav.geonames;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.frontend.cli.annotation.MCRCommand;
+import org.mycore.frontend.cli.annotation.MCRCommandGroup;
+
+/**
+ * Command line commands to manage the local GeoNames cache.
+ */
+@MCRCommandGroup(name = "DITAV GeoNames Commands")
+public class DitavGeoNamesCommands {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @MCRCommand(syntax = "clear geonames cache",
+        help = "Removes all locally cached GeoNames entries.")
+    public static void clearAll() {
+        int count = DitavGeoNamesService.getInstance().clearAll();
+        LOGGER.info("Cleared {} GeoNames cache entries.", count);
+    }
+
+    @MCRCommand(syntax = "clear geonames cache for {0}",
+        help = "Removes the locally cached GeoNames entry for geonameId {0}.")
+    public static void clear(String geonameId) {
+        boolean deleted = DitavGeoNamesService.getInstance().clear(geonameId);
+        if (deleted) {
+            LOGGER.info("Cleared GeoNames cache entry {}.", geonameId);
+        } else {
+            LOGGER.info("No GeoNames cache entry found for {}.", geonameId);
+        }
+    }
+}

--- a/src/main/java/de/gbv/reposis/ditav/geonames/DitavGeoNamesService.java
+++ b/src/main/java/de/gbv/reposis/ditav/geonames/DitavGeoNamesService.java
@@ -1,0 +1,302 @@
+package de.gbv.reposis.ditav.geonames;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.MCRException;
+import org.mycore.common.config.MCRConfiguration2;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Resolves GeoNames entries for a given geonameId and caches the raw GeoNames JSON
+ * response locally below the MyCoRe data directory.
+ * <p>
+ * A lookup first checks the local cache. On a cache miss the entry is fetched from the
+ * GeoNames API (only if a username is configured) and stored in the cache afterwards.
+ * <p>
+ * Configuration:
+ * <ul>
+ *   <li>{@code MCR.DITAV.GeoNames.Username} - GeoNames API username (required for remote lookups)</li>
+ *   <li>{@code MCR.DITAV.GeoNames.BaseURL} - GeoNames JSON endpoint, defaults to {@value #DEFAULT_BASE_URL}</li>
+ *   <li>{@code MCR.DITAV.GeoNames.CacheDir} - optional cache directory, defaults to
+ *       {@code <MCR.datadir>/geonames-cache}</li>
+ * </ul>
+ */
+public final class DitavGeoNamesService {
+
+    public static final String USERNAME_PROPERTY = "MCR.DITAV.GeoNames.Username";
+
+    public static final String BASE_URL_PROPERTY = "MCR.DITAV.GeoNames.BaseURL";
+
+    public static final String CACHE_DIR_PROPERTY = "MCR.DITAV.GeoNames.CacheDir";
+
+    public static final String DEFAULT_BASE_URL = "https://www.geonames.org/getJSON";
+
+    private static final String CACHE_DIR_NAME = "geonames-cache";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /** A valid geonameId consists of digits only. */
+    private static final Pattern GEONAME_ID_PATTERN = Pattern.compile("\\d+");
+
+    /** Matches the numeric geonameId in refs like {@code https://(www.|sws.)geonames.org/554234}. */
+    private static final Pattern REF_ID_PATTERN = Pattern.compile("geonames\\.org/(\\d+)");
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .build();
+
+    private DitavGeoNamesService() {
+    }
+
+    public static DitavGeoNamesService getInstance() {
+        return LazyInstanceHolder.INSTANCE;
+    }
+
+    /**
+     * Extracts the numeric geonameId from a GeoNames reference URL.
+     *
+     * @param ref a reference like {@code https://www.geonames.org/554234}
+     * @return the geonameId or an empty optional if the ref does not contain one
+     */
+    public static Optional<String> extractGeonameId(String ref) {
+        if (ref == null) {
+            return Optional.empty();
+        }
+        Matcher matcher = REF_ID_PATTERN.matcher(ref);
+        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+
+    /**
+     * Extracts the {@code "lng lat"} coordinate pair (WKT axis order) from a GeoNames JSON entry.
+     *
+     * @param entry the parsed GeoNames JSON
+     * @return the coordinate pair or an empty optional if no usable coordinates are present
+     */
+    public static Optional<String> coordinatePair(JsonObject entry) {
+        if (entry == null || !entry.has("lat") || !entry.has("lng")) {
+            return Optional.empty();
+        }
+        try {
+            double lat = entry.get("lat").getAsDouble();
+            double lng = entry.get("lng").getAsDouble();
+            return Optional.of(lng + " " + lat);
+        } catch (NumberFormatException | IllegalStateException e) {
+            LOGGER.warn("GeoNames entry has invalid lat/lng: {}", entry);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Builds a WKT {@code POINT (lng lat)} string from a GeoNames JSON entry, matching the
+     * coordinate format used for the {@code location_common} Solr field type in reposis_common.
+     *
+     * @param entry the parsed GeoNames JSON
+     * @return the WKT point or an empty optional if no usable coordinates are present
+     */
+    public static Optional<String> toWktPoint(JsonObject entry) {
+        return coordinatePair(entry).map(pair -> "POINT (" + pair + ")");
+    }
+
+    /**
+     * @return the directory holding the cached GeoNames JSON files
+     */
+    public Path getCacheDirectory() {
+        Optional<String> configured = MCRConfiguration2.getString(CACHE_DIR_PROPERTY).filter(s -> !s.isBlank());
+        if (configured.isPresent()) {
+            return Paths.get(configured.get());
+        }
+        return Paths.get(MCRConfiguration2.getStringOrThrow("MCR.datadir"), CACHE_DIR_NAME);
+    }
+
+    /**
+     * Resolves the raw GeoNames JSON for the given geonameId, using the local cache first and
+     * fetching from the GeoNames API on a cache miss.
+     *
+     * @param geonameId the numeric geonameId
+     * @return the raw JSON or an empty optional if it could not be resolved
+     */
+    public Optional<String> resolve(String geonameId) {
+        Optional<String> cached = getCached(geonameId);
+        if (cached.isPresent()) {
+            return cached;
+        }
+        return fetchAndStore(geonameId);
+    }
+
+    /**
+     * Like {@link #resolve(String)} but returns the parsed JSON object.
+     */
+    public Optional<JsonObject> resolveAsJson(String geonameId) {
+        return resolve(geonameId).flatMap(DitavGeoNamesService::parse);
+    }
+
+    /**
+     * @return the cached raw JSON for the given geonameId without contacting the GeoNames API
+     */
+    public Optional<String> getCached(String geonameId) {
+        Path file = cacheFile(geonameId);
+        if (Files.isRegularFile(file)) {
+            try {
+                return Optional.of(Files.readString(file, UTF_8));
+            } catch (IOException e) {
+                LOGGER.warn("Could not read GeoNames cache file {}", file, e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Removes the cache entry for a single geonameId.
+     *
+     * @return {@code true} if a cache file existed and was deleted
+     */
+    public boolean clear(String geonameId) {
+        Path file = cacheFile(geonameId);
+        try {
+            boolean deleted = Files.deleteIfExists(file);
+            if (deleted) {
+                LOGGER.info("Removed GeoNames cache entry {}", geonameId);
+            }
+            return deleted;
+        } catch (IOException e) {
+            LOGGER.warn("Could not delete GeoNames cache file {}", file, e);
+            return false;
+        }
+    }
+
+    /**
+     * Removes all cached GeoNames entries.
+     *
+     * @return the number of deleted cache files
+     */
+    public int clearAll() {
+        Path dir = getCacheDirectory();
+        if (!Files.isDirectory(dir)) {
+            return 0;
+        }
+        List<Path> cacheFiles;
+        try (Stream<Path> files = Files.list(dir)) {
+            cacheFiles = files.filter(p -> p.getFileName().toString().endsWith(".json")).toList();
+        } catch (IOException e) {
+            LOGGER.warn("Could not list GeoNames cache directory {}", dir, e);
+            return 0;
+        }
+        int count = 0;
+        for (Path file : cacheFiles) {
+            try {
+                if (Files.deleteIfExists(file)) {
+                    count++;
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Could not delete GeoNames cache file {}", file, e);
+            }
+        }
+        LOGGER.info("Removed {} GeoNames cache entries", count);
+        return count;
+    }
+
+    private Path cacheFile(String geonameId) {
+        if (geonameId == null || !GEONAME_ID_PATTERN.matcher(geonameId).matches()) {
+            throw new MCRException("Invalid geonameId: " + geonameId);
+        }
+        return getCacheDirectory().resolve(geonameId + ".json");
+    }
+
+    private synchronized Optional<String> fetchAndStore(String geonameId) {
+        // re-check the cache: another thread may have fetched it while we waited for the lock
+        Optional<String> cached = getCached(geonameId);
+        if (cached.isPresent()) {
+            return cached;
+        }
+
+        Optional<String> username = MCRConfiguration2.getString(USERNAME_PROPERTY).filter(s -> !s.isBlank());
+        if (username.isEmpty()) {
+            LOGGER.debug("No GeoNames username configured ({}); skipping remote lookup for {}",
+                USERNAME_PROPERTY, geonameId);
+            return Optional.empty();
+        }
+
+        String baseUrl = MCRConfiguration2.getString(BASE_URL_PROPERTY).filter(s -> !s.isBlank())
+            .orElse(DEFAULT_BASE_URL);
+        String uri = baseUrl + "?geonameId=" + URLEncoder.encode(geonameId, UTF_8)
+            + "&username=" + URLEncoder.encode(username.get(), UTF_8);
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
+                .timeout(Duration.ofSeconds(15))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
+            if (response.statusCode() != 200) {
+                LOGGER.warn("GeoNames API returned status {} for geonameId {}", response.statusCode(), geonameId);
+                return Optional.empty();
+            }
+            String body = response.body();
+            Optional<JsonObject> json = parse(body);
+            if (json.isEmpty() || json.get().has("status")) {
+                // GeoNames signals errors (e.g. quota exceeded) with a "status" object
+                LOGGER.warn("GeoNames API error for geonameId {}: {}", geonameId, body);
+                return Optional.empty();
+            }
+            store(geonameId, body);
+            return Optional.of(body);
+        } catch (IOException e) {
+            LOGGER.warn("Could not fetch GeoNames entry {} from {}", geonameId, baseUrl, e);
+            return Optional.empty();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Interrupted while fetching GeoNames entry {}", geonameId, e);
+            return Optional.empty();
+        }
+    }
+
+    private void store(String geonameId, String json) {
+        Path file = cacheFile(geonameId);
+        try {
+            Files.createDirectories(file.getParent());
+            Files.writeString(file, json, UTF_8);
+            LOGGER.info("Cached GeoNames entry {} at {}", geonameId, file);
+        } catch (IOException e) {
+            LOGGER.warn("Could not write GeoNames cache file {}", file, e);
+        }
+    }
+
+    private static Optional<JsonObject> parse(String json) {
+        try {
+            JsonElement element = JsonParser.parseString(json);
+            if (element.isJsonObject()) {
+                return Optional.of(element.getAsJsonObject());
+            }
+        } catch (RuntimeException e) {
+            LOGGER.warn("Could not parse GeoNames JSON: {}", json, e);
+        }
+        return Optional.empty();
+    }
+
+    private static final class LazyInstanceHolder {
+        private static final DitavGeoNamesService INSTANCE = new DitavGeoNamesService();
+    }
+}

--- a/src/main/java/de/gbv/reposis/ditav/restapi/DitavJerseyAPIDeployer.java
+++ b/src/main/java/de/gbv/reposis/ditav/restapi/DitavJerseyAPIDeployer.java
@@ -1,0 +1,66 @@
+package de.gbv.reposis.ditav.restapi;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.mycore.common.events.MCRStartupHandler.AutoExecutable;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRegistration;
+
+/**
+ * Deploys the DITAV Jersey REST API programmatically at runtime.
+ * <p>
+ * This is necessary because the module JAR is added to the classpath at runtime, after the servlet
+ * container has already started - the same approach the CMS module uses for its API.
+ */
+public class DitavJerseyAPIDeployer implements AutoExecutable {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String SERVLET_NAME = "DitavRestAPI";
+
+    private static final String URL_PATTERN = "/api/geonames/*";
+
+    @Override
+    public String getName() {
+        return "DitavJerseyAPIDeployer";
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public void startUp(ServletContext servletContext) {
+        if (servletContext == null) {
+            LOGGER.warn("ServletContext is null, cannot deploy DITAV REST API");
+            return;
+        }
+
+        if (servletContext.getServletRegistration(SERVLET_NAME) != null) {
+            LOGGER.info("DITAV REST API servlet already registered");
+            return;
+        }
+
+        try {
+            ServletRegistration.Dynamic servlet = servletContext.addServlet(
+                SERVLET_NAME,
+                new ServletContainer(new DitavRestApp()));
+
+            if (servlet == null) {
+                LOGGER.error("Failed to register DITAV REST API servlet - addServlet returned null");
+                return;
+            }
+
+            servlet.addMapping(URL_PATTERN);
+            servlet.setLoadOnStartup(1);
+            servlet.setAsyncSupported(true);
+
+            LOGGER.info("Successfully deployed DITAV REST API at {}", URL_PATTERN);
+        } catch (Exception e) {
+            LOGGER.error("Failed to deploy DITAV REST API", e);
+        }
+    }
+}

--- a/src/main/java/de/gbv/reposis/ditav/restapi/DitavRestApp.java
+++ b/src/main/java/de/gbv/reposis/ditav/restapi/DitavRestApp.java
@@ -1,0 +1,51 @@
+package de.gbv.reposis.ditav.restapi;
+
+import org.apache.logging.log4j.LogManager;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.frontend.jersey.access.MCRRequestScopeACLFilter;
+import org.mycore.restapi.MCRCORSResponseFilter;
+import org.mycore.restapi.MCRIgnoreClientAbortInterceptor;
+import org.mycore.restapi.MCRSessionFilter;
+import org.mycore.restapi.MCRTransactionFilter;
+
+/**
+ * Jersey REST application for the DITAV API.
+ * <p>
+ * It is registered programmatically by {@link DitavJerseyAPIDeployer} because the module JAR is
+ * loaded at runtime, after the servlet container has already started (the same reason the CMS
+ * module deploys its API programmatically).
+ */
+public class DitavRestApp extends ResourceConfig {
+
+    public static final String RESOURCE_PACKAGES_PROPERTY = "MCR.DITAV.API.Resource.Packages";
+
+    public DitavRestApp() {
+        super();
+        initAppName();
+        property(ServerProperties.APPLICATION_NAME, getApplicationName());
+        packages(getRestPackages());
+        property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
+        register(MCRSessionFilter.class);
+        register(MCRTransactionFilter.class);
+        register(DitavRestFeature.class);
+        register(MCRCORSResponseFilter.class);
+        register(MCRRequestScopeACLFilter.class);
+        register(MCRIgnoreClientAbortInterceptor.class);
+    }
+
+    protected void initAppName() {
+        setApplicationName("DITAV-API " + getVersion());
+        LogManager.getLogger().info("Initialize {}", this::getApplicationName);
+    }
+
+    protected String getVersion() {
+        return "1.0";
+    }
+
+    protected String[] getRestPackages() {
+        return MCRConfiguration2.getOrThrow(RESOURCE_PACKAGES_PROPERTY, MCRConfiguration2::splitValue)
+            .toArray(String[]::new);
+    }
+}

--- a/src/main/java/de/gbv/reposis/ditav/restapi/DitavRestFeature.java
+++ b/src/main/java/de/gbv/reposis/ditav/restapi/DitavRestFeature.java
@@ -1,0 +1,62 @@
+package de.gbv.reposis.ditav.restapi;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.frontend.jersey.feature.MCRJerseyDefaultFeature;
+import org.mycore.restapi.MCREnableTransactionFilter;
+import org.mycore.restapi.annotations.MCRRequireTransaction;
+
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Jersey configuration for the DITAV API, modelled after the CMS module's feature.
+ *
+ * @see MCRJerseyDefaultFeature
+ */
+@Provider
+public class DitavRestFeature extends MCRJerseyDefaultFeature {
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        Class<?> resourceClass = resourceInfo.getResourceClass();
+        Method resourceMethod = resourceInfo.getResourceMethod();
+        if (requiresTransaction(resourceClass, resourceMethod)) {
+            context.register(MCREnableTransactionFilter.class);
+        }
+        super.configure(resourceInfo, context);
+    }
+
+    protected boolean requiresTransaction(Class<?> resourceClass, Method resourceMethod) {
+        return resourceClass.getAnnotation(MCRRequireTransaction.class) != null
+            || resourceMethod.getAnnotation(MCRRequireTransaction.class) != null;
+    }
+
+    @Override
+    protected List<String> getPackages() {
+        return MCRConfiguration2.getString(DitavRestApp.RESOURCE_PACKAGES_PROPERTY)
+            .map(MCRConfiguration2::splitValue)
+            .orElse(Stream.empty())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    protected void registerSessionHookFilter(FeatureContext context) {
+        // transaction handling is already implemented by MCRSessionFilter
+    }
+
+    @Override
+    protected void registerTransactionFilter(FeatureContext context) {
+        // transaction handling is already implemented by MCRSessionFilter
+    }
+
+    @Override
+    protected void registerAccessFilter(FeatureContext context, Class<?> resourceClass, Method resourceMethod) {
+        super.registerAccessFilter(context, resourceClass, resourceMethod);
+    }
+}

--- a/src/main/java/de/gbv/reposis/ditav/restapi/resource/DitavGeoNamesResource.java
+++ b/src/main/java/de/gbv/reposis/ditav/restapi/resource/DitavGeoNamesResource.java
@@ -1,0 +1,42 @@
+package de.gbv.reposis.ditav.restapi.resource;
+
+import de.gbv.reposis.ditav.geonames.DitavGeoNamesService;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * REST resource exposing the locally cached GeoNames entries.
+ * <p>
+ * Deployed by {@link de.gbv.reposis.ditav.restapi.DitavJerseyAPIDeployer} and therefore available
+ * at {@code /api/geonames/{geonameId}}.
+ */
+@Path("/")
+public class DitavGeoNamesResource {
+
+    /**
+     * Returns the GeoNames JSON for the given geonameId. The entry is served from the local
+     * cache; on a cache miss it is fetched from the GeoNames API and cached.
+     *
+     * @param geonameId the numeric geonameId, e.g. {@code 554234}
+     * @return the GeoNames JSON, {@code 400} for a malformed id or {@code 404} if it cannot be resolved
+     */
+    @GET
+    @Path("{geonameId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getGeoName(@PathParam("geonameId") String geonameId) {
+        if (geonameId == null || !geonameId.matches("\\d+")) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("{\"error\": \"geonameId must be numeric\"}")
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+        }
+        return DitavGeoNamesService.getInstance().resolve(geonameId)
+            .map(json -> Response.ok(json).build())
+            .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
+    }
+}

--- a/src/main/resources/config/reposis_ditav/mycore.properties
+++ b/src/main/resources/config/reposis_ditav/mycore.properties
@@ -32,6 +32,29 @@ MCR.Solr.Indexer.File.AccumulatorList=%MCR.Solr.Indexer.File.AccumulatorList%,de
 
 ###################################################################################################
 #                                                                                                 #
+# GeoNames cache                                                                                  #
+#                                                                                                 #
+###################################################################################################
+
+# GeoNames API username used for remote lookups (required to populate the cache)
+#MCR.DITAV.GeoNames.Username=
+
+# GeoNames JSON endpoint
+MCR.DITAV.GeoNames.BaseURL=https://www.geonames.org/getJSON
+
+# Cache directory; defaults to <MCR.datadir>/geonames-cache when left empty
+MCR.DITAV.GeoNames.CacheDir=
+
+# CLI commands to manage the GeoNames cache
+MCR.CLI.Classes.Internal=%MCR.CLI.Classes.Internal%,de.gbv.reposis.ditav.geonames.DitavGeoNamesCommands
+
+# REST API: the module JAR is loaded at runtime, so the Jersey app is deployed programmatically
+# (same approach as the CMS module). The resource is then available at /api/geonames/{geonameId}.
+MCR.DITAV.API.Resource.Packages=de.gbv.reposis.ditav.restapi.resource
+MCR.Startup.Class=%MCR.Startup.Class%,de.gbv.reposis.ditav.restapi.DitavJerseyAPIDeployer
+
+###################################################################################################
+#                                                                                                 #
 # Access control                                                                                  #
 #                                                                                                 #
 ###################################################################################################

--- a/src/main/resources/config/reposis_ditav/solr/main/solr-schema.json
+++ b/src/main/resources/config/reposis_ditav/solr/main/solr-schema.json
@@ -88,5 +88,65 @@
       "stored": true,
       "indexed": true
     }
+  },
+  {
+    "add-field": {
+      "name": "ditav.tei.geonames_id",
+      "type": "strings",
+      "multiValued": true,
+      "stored": true,
+      "indexed": true
+    }
+  },
+  {
+    "add-field": {
+      "name": "ditav.tei.geonames_link",
+      "type": "strings",
+      "multiValued": true,
+      "stored": true,
+      "indexed": true
+    }
+  },
+  {
+    "add-field": {
+      "name": "ditav.tei.place",
+      "type": "strings",
+      "multiValued": true,
+      "stored": true,
+      "indexed": true
+    }
+  },
+  {
+    "add-field-type": {
+      "name": "location_ditav",
+      "class": "solr.RptWithGeometrySpatialField",
+      "geo": true,
+      "spatialContextFactory": "Geo3D",
+      "distanceUnits": "kilometers",
+      "maxDistErr": "0.001",
+      "distErrPct": "0.025",
+      "planetModel": "WGS84",
+      "format": "WKT"
+    }
+  },
+  {
+    "add-field": {
+      "name": "ditav.tei.coordinates",
+      "type": "location_ditav",
+      "multiValued": true
+    }
+  },
+  {
+    "add-field": {
+      "name": "ditav.tei.coordinates.str",
+      "type": "string",
+      "multiValued": true
+    }
+  },
+  {
+    "add-copy-field": {
+      "source": "ditav.tei.coordinates",
+      "dest": "ditav.tei.coordinates.str"
+    }
   }
 ]

--- a/src/test/java/de/gbv/reposis/ditav/DitavTEIAccumulatorTest.java
+++ b/src/test/java/de/gbv/reposis/ditav/DitavTEIAccumulatorTest.java
@@ -1,6 +1,7 @@
 package de.gbv.reposis.ditav;
 
 import static de.gbv.reposis.ditav.DitavTEIAccumulator.DITAV_GENERIC_FILE_LINK_SOLR_FIELD;
+import static de.gbv.reposis.ditav.DitavTEIAccumulator.DITAV_GEONAMES_ID_SOLR_FIELD;
 import static de.gbv.reposis.ditav.DitavTEIAccumulator.DITAV_ORGANIZATION_FILE_LINK_SOLR_FIELD;
 import static de.gbv.reposis.ditav.DitavTEIAccumulator.DITAV_PERSON_FILE_LINK_SOLR_FIELD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,10 +18,16 @@ import java.util.Set;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.jupiter.api.Test;
 import org.mycore.common.MCRClassTools;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
 import org.mycore.test.MyCoReTest;
 
 @MyCoReTest
+// disable remote GeoNames lookups so the accumulator works offline during tests
+@MCRTestConfiguration(properties = @MCRTestProperty(key = "MCR.DITAV.GeoNames.Username", empty = true))
 class DitavTEIAccumulatorTest {
+
+    private static final Set<String> EXPECTED_GEONAME_IDS = Set.of("2747373", "2910831");
 
     private static final String PERS_PREFIX = "https://uri.gbv.de/terminology/lod_persons/";
 
@@ -66,6 +73,9 @@ class DitavTEIAccumulatorTest {
         List<Object> personValues = List.copyOf(solrDocument.getFieldValues(DITAV_PERSON_FILE_LINK_SOLR_FIELD));
         assertEquals(EXPECTED_PERSONS.size(), personValues.size(),
             "no duplicate values in person field");
+
+        Set<String> geonameIds = asStringSet(solrDocument.getFieldValues(DITAV_GEONAMES_ID_SOLR_FIELD));
+        assertEquals(EXPECTED_GEONAME_IDS, geonameIds, "geonameIds extracted from placeName refs (deduped)");
 
         Files.deleteIfExists(file);
     }

--- a/src/test/java/de/gbv/reposis/ditav/geonames/DitavGeoNamesServiceTest.java
+++ b/src/test/java/de/gbv/reposis/ditav/geonames/DitavGeoNamesServiceTest.java
@@ -1,0 +1,97 @@
+package de.gbv.reposis.ditav.geonames;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.test.MyCoReTest;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+@MyCoReTest
+// no username -> no remote lookups, the tests rely solely on the local cache
+@MCRTestConfiguration(properties = @MCRTestProperty(key = "MCR.DITAV.GeoNames.Username", empty = true))
+class DitavGeoNamesServiceTest {
+
+    @Test
+    void extractGeonameId() {
+        assertEquals(Optional.of("554234"),
+            DitavGeoNamesService.extractGeonameId("https://www.geonames.org/554234"));
+        assertEquals(Optional.of("554234"),
+            DitavGeoNamesService.extractGeonameId("https://sws.geonames.org/554234"));
+        assertEquals(Optional.of("554234"),
+            DitavGeoNamesService.extractGeonameId("https://geonames.org/554234/"));
+        assertTrue(DitavGeoNamesService.extractGeonameId("https://example.org/foo").isEmpty());
+        assertTrue(DitavGeoNamesService.extractGeonameId(null).isEmpty());
+    }
+
+    @Test
+    void toWktPoint() {
+        JsonObject entry = JsonParser.parseString("{\"name\":\"Königsberg\",\"lat\":54.71,\"lng\":20.5}")
+            .getAsJsonObject();
+        assertEquals(Optional.of("20.5 54.71"), DitavGeoNamesService.coordinatePair(entry));
+        assertEquals(Optional.of("POINT (20.5 54.71)"), DitavGeoNamesService.toWktPoint(entry));
+
+        JsonObject noCoords = JsonParser.parseString("{\"name\":\"Nowhere\"}").getAsJsonObject();
+        assertTrue(DitavGeoNamesService.coordinatePair(noCoords).isEmpty());
+        assertTrue(DitavGeoNamesService.toWktPoint(noCoords).isEmpty());
+    }
+
+    @Test
+    void resolveFromCache(@TempDir Path cacheDir) throws IOException {
+        MCRConfiguration2.set(DitavGeoNamesService.CACHE_DIR_PROPERTY, cacheDir.toString());
+        String json = "{\"geonameId\":554234,\"name\":\"Kaliningrad\",\"lat\":54.71,\"lng\":20.5}";
+        Files.writeString(cacheDir.resolve("554234.json"), json);
+
+        DitavGeoNamesService service = DitavGeoNamesService.getInstance();
+        Optional<String> resolved = service.resolve("554234");
+        assertTrue(resolved.isPresent());
+        assertEquals(json, resolved.get());
+
+        Optional<JsonObject> parsed = service.resolveAsJson("554234");
+        assertTrue(parsed.isPresent());
+        assertEquals("Kaliningrad", parsed.get().get("name").getAsString());
+    }
+
+    @Test
+    void resolveMissWithoutUsername(@TempDir Path cacheDir) {
+        MCRConfiguration2.set(DitavGeoNamesService.CACHE_DIR_PROPERTY, cacheDir.toString());
+        // cache miss and no username -> empty result, no remote call, no exception
+        assertTrue(DitavGeoNamesService.getInstance().resolve("999999").isEmpty());
+    }
+
+    @Test
+    void clearSingleEntry(@TempDir Path cacheDir) throws IOException {
+        MCRConfiguration2.set(DitavGeoNamesService.CACHE_DIR_PROPERTY, cacheDir.toString());
+        Files.writeString(cacheDir.resolve("554234.json"), "{}");
+
+        DitavGeoNamesService service = DitavGeoNamesService.getInstance();
+        assertTrue(service.getCached("554234").isPresent());
+        assertTrue(service.clear("554234"));
+        assertTrue(service.getCached("554234").isEmpty());
+        assertFalse(service.clear("554234"));
+    }
+
+    @Test
+    void clearAllEntries(@TempDir Path cacheDir) throws IOException {
+        MCRConfiguration2.set(DitavGeoNamesService.CACHE_DIR_PROPERTY, cacheDir.toString());
+        Files.writeString(cacheDir.resolve("1.json"), "{}");
+        Files.writeString(cacheDir.resolve("2.json"), "{}");
+        Files.writeString(cacheDir.resolve("note.txt"), "ignore");
+
+        DitavGeoNamesService service = DitavGeoNamesService.getInstance();
+        assertEquals(2, service.clearAll());
+        assertTrue(Files.exists(cacheDir.resolve("note.txt")), "non-json files must be kept");
+    }
+}


### PR DESCRIPTION
[Link zum Ticket](https://jira.gbv.de/projects/QUED/issues/QUED-179)

## Kontext
QUED-179: LoD – Integration der Karte auf der Startseite analog zu SovSur.
Die Geodaten müssen in den Metadaten liegen. Dieser PR ist die **Vorarbeit**:
Er extrahiert die Geodaten aus den TEI-Metadaten und indexiert sie nach Solr,
sodass darauf eine Karte aufsetzen kann.

## Änderungen
- **`DitavTEIAccumulator`**: löst `tei:placeName`-Referenzen auf `geonames.org`
  auf. Indexiert `geonameId`, Link und Ortsnamen. Alle aufgelösten Koordinaten
  eines Dokuments werden zu **einem** WKT-Geometrie-Wert zusammengefasst
  (`POINT` bei einem Ort, `GEOMETRYCOLLECTION` bei mehreren) — analog dazu, wie
  MIR/reposis_common ein Polygon als eine Geometrie ablegt. Damit hält das
  single-valued Spatial-Feld alle Orte ohne DocValues-Konflikt.
- **Solr-Schema**: neuer Feldtyp `location_ditav` (gleiche Definition wie
  `location_common` in reposis_common, aber eigener Name, damit beide Module
  parallel laufen und jedes für sich funktioniert). Neue Felder
  `ditav.tei.geonames_id`, `ditav.tei.geonames_link`, `ditav.tei.place`,
  `ditav.tei.coordinates`.
- **`DitavGeoNamesService`**: lokaler Cache unterhalb `MCR.datadir`. Lookup
  prüft erst den Cache; bei Cache-Miss wird über die GeoNames-API geladen
  (nur wenn Username konfiguriert) und abgelegt. API-Muster wie im qed-Frontend.
- **`DitavGeoNamesCommands`**: CLI zum Leeren des Caches — einzelne id
  (`clear geonames cache for {0}`) oder komplett (`clear geonames cache`).
- **REST-API** unter `/api/geonames/{geonameId}`: programmatisch deployt wie im
  CMS-Modul (`DitavRestApp` + `DitavRestFeature` + `DitavJerseyAPIDeployer`),
  da das Modul-JAR zur Laufzeit geladen wird und Classpath-Scanning es sonst
  nicht findet.

## Konfiguration
```
#MCR.DITAV.GeoNames.Username=     # pro Deployment setzen; leer -> kein Remote-Lookup
MCR.DITAV.GeoNames.BaseURL=https://www.geonames.org/getJSON
MCR.DITAV.GeoNames.CacheDir=      # leer -> <MCR.datadir>/geonames-cache
```

## Tests
- `DitavGeoNamesServiceTest`: id-Extraktion, WKT-Punkt, Cache-Resolve,
  Miss ohne Username (kein Remote-Call), Cache leeren (einzeln/alle).
- `DitavTEIAccumulatorTest`: erwartete geonameIds im Solr-Dokument.
- `mvn clean install` grün (11 Tests).

## Hinweis / Migration
Live-Solr-Core hat `ditav.tei.coordinates` ggf. noch unter altem Typ; für die
Umbenennung auf `location_ditav` Feld droppen bzw. Core neu anlegen
(Definition identisch, funktioniert sonst weiter).

## Offen / Abstimmung
Karten-Frontend selbst ist nicht Teil dieses PRs. Ggf. noch mit André Herzog
abstimmen, wie die Geodaten in den Metadaten final aussehen sollen.